### PR TITLE
Upgrade to Orchard Core RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
 dist: bionic
-dotnet: 2.2.100
+dotnet: 3.0
 
 install:
 - dotnet restore

--- a/Etch.OrchardCore.Search.csproj
+++ b/Etch.OrchardCore.Search.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.0.1-beta</Version>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+    <Version>0.1.0-rc1</Version>
     <PackageId>Etch.OrchardCore.Search</PackageId>
     <Title>Site Search</Title>
     <Authors>Etch UK</Authors>
@@ -18,20 +18,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.ContentManagement.Display" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.ContentTypes" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Indexing.Abstractions" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Lucene" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Navigation" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Queries.Abstractions" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-beta3-71077" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.ContentManagement.Display" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.ContentTypes" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Indexing.Abstractions" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Lucene" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Navigation" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Queries.Abstractions" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc1-10004" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Etch UK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Migrations/create.recipe.json
+++ b/Migrations/create.recipe.json
@@ -6,8 +6,12 @@
     "website": "https://etchuk.com",
     "version": "0.1.0",
     "issetuprecipe": false,
-    "categories": ["search"],
-    "tags": ["search"],
+    "categories": [
+        "search"
+    ],
+    "tags": [
+        "search"
+    ],
     "steps": [
         {
             "name": "ContentDefinition",
@@ -16,41 +20,48 @@
                     "Name": "SiteSearch",
                     "DisplayName": "Site Search",
                     "Settings": {
-                        "Creatable": "True",
-                        "Draftable": "True",
-                        "Versionable": "True",
-                        "Listable": "True",
-                        "Securable": "True",
-                        "Stereotype": null
+                        "ContentTypeSettings": {
+                            "Creatable": true,
+                            "Listable": true,
+                            "Draftable": true,
+                            "Versionable": true,
+                            "Securable": true
+                        },
+                        "FullTextAspectSettings": {}
                     },
                     "ContentTypePartDefinitionRecords": [
                         {
                             "PartName": "SiteSearch",
                             "Name": "SiteSearch",
                             "Settings": {
-                                "Position": "2"
+                                "ContentTypePartSettings": {
+                                    "Position": "2"
+                                }
                             }
                         },
                         {
                             "PartName": "AutoroutePart",
                             "Name": "AutoroutePart",
                             "Settings": {
-                                "DisplayName": null,
-                                "Description": null,
-                                "Editor": null,
-                                "Pattern": "{{ ContentItem | display_text | slugify }}",
-                                "AllowCustomPath": "True",
-                                "AllowUpdatePath": "True",
-                                "ShowHomepageOption": "False",
-                                "ContentIndexSettings": {},
-                                "Position": "1"
+                                "ContentTypePartSettings": {
+                                    "Position": "1"
+                                },
+                                "AutoroutePartSettings": {
+                                    "AllowCustomPath": true,
+                                    "Pattern": "{{ ContentItem | display_text | slugify }}",
+                                    "AllowUpdatePath": true,
+                                    "ShowHomepageOption": false
+                                },
+                                "ContentIndexSettings": {}
                             }
                         },
                         {
                             "PartName": "TitlePart",
                             "Name": "TitlePart",
                             "Settings": {
-                                "Position": "0"
+                                "ContentTypePartSettings": {
+                                    "Position": "0"
+                                }
                             }
                         }
                     ]
@@ -73,7 +84,9 @@
         },
         {
             "name": "lucene-index",
-            "Indices": ["Search"]
+            "Indices": [
+                "Search"
+            ]
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Module for [Orchard Core](https://github.com/OrchardCMS/OrchardCore) for adding 
 
 ## Orchard Core Reference
 
-This module is referencing the beta 3 build of Orchard Core ([`1.0.0-beta3-71077`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-beta3-71077)).
+This module is referencing the RC1 build of Orchard Core ([`1.0.0-rc1-10004`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc1-10004)).
 
 ## Installing
 

--- a/Views/SiteSearch.Edit.cshtml
+++ b/Views/SiteSearch.Edit.cshtml
@@ -71,7 +71,7 @@
             <option value="">- Please select query -</option>
             @foreach (var query in Model.Queries)
             {
-                <option value="@query.Name" @(query.Name == Model.Query ? "selected=\"selected\"" : "")>@query.Name</option>
+                <option value="@query.Name" selected="@(query.Name == Model.Query ? "selected" : "")">@query.Name</option>
             }
         </select>
         <span asp-validation-for="Query"></span>

--- a/azure-pipelines-prerelease.yml
+++ b/azure-pipelines-prerelease.yml
@@ -1,5 +1,6 @@
 pool:
-  name: Hosted VS2017
+  vmImage: 'windows-2019'
+  
 variables:
   BuildConfiguration: 'Release'
 

--- a/azure-pipelines-stable.yml
+++ b/azure-pipelines-stable.yml
@@ -1,5 +1,6 @@
 pool:
-  name: Hosted VS2017
+  vmImage: 'windows-2019'
+  
 variables:
   BuildConfiguration: 'Release'
 


### PR DESCRIPTION
- Change target framework to .NET core 3.0
- Add `AddRazorSupportForMvc` to signify class library contains UI
components for MVC
- Update all Orchard Core dependencies to point to rc1 release
- Swap `Microsoft.AspNetCore` references for `FrameworkReference`
- Update Azure pipeline build script to use .NET core 3.0
- Update Travis build script to use .NET core 3.0
- Update docs for Orchard Core reference
- Bump version number and update suffix to "rc1"