### PR TITLE
Move searchable part to own tab

### DIFF
--- a/Drivers/SearchablePartDisplay.cs
+++ b/Drivers/SearchablePartDisplay.cs
@@ -18,7 +18,8 @@ namespace Etch.OrchardCore.Search.Drivers
             {
                 m.ExcludeFromResults = part.ExcludeFromResults;
                 m.Keywords = part.Keywords;
-            });
+            })
+            .Location("Parts#Search:5");
         }
 
         public async override Task<IDisplayResult> UpdateAsync(SearchablePart part, IUpdateModel updater)

--- a/Etch.OrchardCore.Search.csproj
+++ b/Etch.OrchardCore.Search.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <Version>0.1.0-rc1</Version>
+    <Version>0.1.1-rc1</Version>
     <PackageId>Etch.OrchardCore.Search</PackageId>
     <Title>Site Search</Title>
     <Authors>Etch UK</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules.Manifest;
     Category = "Content",
     Description = "Provides ability to setup site search.",
     Name = "Site Search",
-    Version = "0.1.0",
+    Version = "0.1.1",
     Website = "https://etchuk.com",
     Dependencies = new[] { "OrchardCore.Autoroute", "OrchardCore.Lucene", "OrchardCore.Queries", "OrchardCore.Title" }
 )]


### PR DESCRIPTION
Display searchable part editor in it's own "Search" tab.